### PR TITLE
Feature: Morgan을 이용한 log file화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ src/configs/greenlock.d
 
 # Firebase Json
 src/configs/serviceAccount.json
+
+#log File
+logs/*.log

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,6 @@
 import express from 'express';
+import fs from 'fs';
+import moment from 'moment-timezone';
 import morgan from 'morgan';
 import { useExpressServer } from 'routing-controllers';
 import { AuthHelper } from './middleware/AuthHelper';
@@ -9,6 +11,16 @@ useExpressServer(app, {
   validation: false,
   currentUserChecker: AuthHelper.currentUserChecker,
 });
+
+morgan.token('date', (req, res, tz) => {
+  return moment().tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss');
+});
+morgan.format('myformat', ':remote-addr - :remote-user [:date] ":method :url" :status :res[content-length] - :response-time ms');
+app.use(
+  morgan('myformat', {
+    stream: fs.createWriteStream('./logs/access.log', { flags: 'a' }),
+  })
+);
 app.use(morgan('dev'));
 
 export default app;


### PR DESCRIPTION
## Main development
- Morgan을 이용한 log file화
## Features
### Morgan을 이용한 log file화
- logs 디렉토리가 없으면 에러가 나서 logs/.gitkeep을 만들어 git에 디렉토리 유지하게 만듬
- logs/access.log에 로그가 적히게 됨
- 형식은 다음과 같다. 아래의 정보가 없는 경우 -로 표시된다.
- 접속한 IP - 인증받은 user명 [접속 시간] "method URI" code content-len - morganResponseTime ms
- ex) 127.0.0.1 - - [2020-06-21 00:42:41] "GET /oauth/google/login" 302 798 - - ms

